### PR TITLE
Update fonttools test cases

### DIFF
--- a/fonttools-tests/PairPosSubtable.fea
+++ b/fonttools-tests/PairPosSubtable.fea
@@ -4,7 +4,6 @@ languagesystem latn dflt;
 @group1 = [b o];
 @group2 = [c d];
 @group3 = [v w];
-@group4 = [];
 
 lookup kernlookup {
     pos A V -34;
@@ -13,9 +12,6 @@ lookup kernlookup {
     subtable;
     pos @group1 @group3 -10;
     pos @group3 @group2 -20;
-    subtable;
-    pos @group4 @group1 -10;
-    pos @group4 @group4 -10;
 } kernlookup;
 
 feature kern {

--- a/fonttools-tests/STAT_test.ttx
+++ b/fonttools-tests/STAT_test.ttx
@@ -8,9 +8,6 @@
     <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
       Roman
     </namerecord>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x411">
-      ローマン
-    </namerecord>
     <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
       Optical Size
     </namerecord>
@@ -67,6 +64,9 @@
     </namerecord>
     <namerecord nameID="275" platformID="3" platEncID="1" langID="0x409">
       Caption
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x411">
+      ローマン
     </namerecord>
   </name>
 

--- a/fonttools-tests/name.fea
+++ b/fonttools-tests/name.fea
@@ -1,16 +1,16 @@
 table name {
 #test-fea2fea:
-  nameid 1 "Ignored-1";
+  nameid 1 "Test1";
 #test-fea2fea:
-  nameid 2 "Ignored-2";
+  nameid 2 "Test2";
 #test-fea2fea:
-  nameid 3 "Ignored-3";
+  nameid 3 "Test3";
 #test-fea2fea:
-  nameid 4 "Ignored-4";
+  nameid 4 "Test4";
 #test-fea2fea:
-  nameid 0x5 "Ignored-5";
+  nameid 5 "Test5";
 #test-fea2fea:
-    nameid 06 "Ignored-6";
+    nameid 6 "Test6";
 #test-fea2fea: nameid 7 "Test7";
   nameid 7 3 "Test7";
     nameid 8 1 "Test8";

--- a/fonttools-tests/name.ttx
+++ b/fonttools-tests/name.ttx
@@ -2,20 +2,38 @@
 <ttFont>
 
   <name>
-    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
-      Test7
-    </namerecord>
     <namerecord nameID="8" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Test8
-    </namerecord>
-    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
-      Test9
     </namerecord>
     <namerecord nameID="10" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Test10
     </namerecord>
     <namerecord nameID="11" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Test11
+    </namerecord>
+    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
+      Test1
+    </namerecord>
+    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
+      Test2
+    </namerecord>
+    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
+      Test3
+    </namerecord>
+    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
+      Test4
+    </namerecord>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      Test5
+    </namerecord>
+    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
+      Test6
+    </namerecord>
+    <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
+      Test7
+    </namerecord>
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+      Test9
     </namerecord>
   </name>
 

--- a/fonttools-tests/spec6h_ii.ttx
+++ b/fonttools-tests/spec6h_ii.ttx
@@ -112,23 +112,25 @@
         </MarkBasePos>
       </Lookup>
       <Lookup index="2">
-        <LookupType value="7"/>
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
-        <ContextPos index="0" Format="3">
-          <!-- GlyphCount=3 -->
-          <!-- PosCount=2 -->
-          <Coverage index="0">
+        <ChainContextPos index="0" Format="3">
+          <!-- BacktrackGlyphCount=0 -->
+          <!-- InputGlyphCount=3 -->
+          <InputCoverage index="0">
             <Glyph value="T"/>
-          </Coverage>
-          <Coverage index="1">
+          </InputCoverage>
+          <InputCoverage index="1">
             <Glyph value="c"/>
             <Glyph value="o"/>
-          </Coverage>
-          <Coverage index="2">
+          </InputCoverage>
+          <InputCoverage index="2">
             <Glyph value="grave"/>
             <Glyph value="acute"/>
-          </Coverage>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- PosCount=2 -->
           <PosLookupRecord index="0">
             <SequenceIndex value="0"/>
             <LookupListIndex value="0"/>
@@ -137,7 +139,7 @@
             <SequenceIndex value="2"/>
             <LookupListIndex value="1"/>
           </PosLookupRecord>
-        </ContextPos>
+        </ChainContextPos>
       </Lookup>
     </LookupList>
   </GPOS>

--- a/fonttools-tests/spec6h_iii_3d.ttx
+++ b/fonttools-tests/spec6h_iii_3d.ttx
@@ -30,23 +30,25 @@
     <LookupList>
       <!-- LookupCount=2 -->
       <Lookup index="0">
-        <LookupType value="7"/>
+        <LookupType value="8"/>
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
-        <ContextPos index="0" Format="3">
-          <!-- GlyphCount=2 -->
-          <!-- PosCount=1 -->
-          <Coverage index="0">
+        <ChainContextPos index="0" Format="3">
+          <!-- BacktrackGlyphCount=0 -->
+          <!-- InputGlyphCount=2 -->
+          <InputCoverage index="0">
             <Glyph value="L"/>
-          </Coverage>
-          <Coverage index="1">
+          </InputCoverage>
+          <InputCoverage index="1">
             <Glyph value="quoteright"/>
-          </Coverage>
+          </InputCoverage>
+          <!-- LookAheadGlyphCount=0 -->
+          <!-- PosCount=1 -->
           <PosLookupRecord index="0">
             <SequenceIndex value="1"/>
             <LookupListIndex value="1"/>
           </PosLookupRecord>
-        </ContextPos>
+        </ChainContextPos>
       </Lookup>
       <Lookup index="1">
         <LookupType value="1"/>

--- a/fonttools-tests/spec8b.ttx
+++ b/fonttools-tests/spec8b.ttx
@@ -2,14 +2,14 @@
 <ttFont>
 
   <name>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
-      Win MinionPro Size Name
-    </namerecord>
     <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Mac MinionPro Size Name
     </namerecord>
     <namerecord nameID="256" platformID="1" platEncID="0" langID="0x5" unicode="True">
       Mac MinionPro Size Name
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Win MinionPro Size Name
     </namerecord>
   </name>
 
@@ -37,7 +37,7 @@
           <FeatureParamsSize>
             <DesignSize value="10.0"/>
             <SubfamilyID value="3"/>
-            <SubfamilyNameID value="256"/>  <!-- Win MinionPro Size Name -->
+            <SubfamilyNameID value="256"/>  <!-- Mac MinionPro Size Name -->
             <RangeStart value="8.0"/>
             <RangeEnd value="13.9"/>
           </FeatureParamsSize>

--- a/fonttools-tests/spec8c.ttx
+++ b/fonttools-tests/spec8c.ttx
@@ -2,17 +2,17 @@
 <ttFont>
 
   <name>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
-      Feature description for MS Platform, script Unicode, language English
-    </namerecord>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x411">
-      Feature description for MS Platform, script Unicode, language Japanese
-    </namerecord>
     <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Feature description for Apple Platform, script Roman, language unspecified
     </namerecord>
     <namerecord nameID="256" platformID="1" platEncID="1" langID="0xc" unicode="True">
       Feature description for Apple Platform, script Japanese, language Japanese
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Feature description for MS Platform, script Unicode, language English
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x411">
+      Feature description for MS Platform, script Unicode, language Japanese
     </namerecord>
   </name>
 
@@ -39,7 +39,7 @@
         <Feature>
           <FeatureParamsStylisticSet>
             <Version value="0"/>
-            <UINameID value="256"/>  <!-- Feature description for MS Platform, script Unicode, language English -->
+            <UINameID value="256"/>  <!-- Feature description for Apple Platform, script Roman, language unspecified -->
           </FeatureParamsStylisticSet>
           <!-- LookupCount=1 -->
           <LookupListIndex index="0" value="0"/>

--- a/fonttools-tests/spec8d.ttx
+++ b/fonttools-tests/spec8d.ttx
@@ -2,34 +2,34 @@
 <ttFont>
 
   <name>
-    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
       uilabel simple a
     </namerecord>
-    <namerecord nameID="256" platformID="1" platEncID="0" langID="0x0" unicode="True">
+    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      tool tip simple a
+    </namerecord>
+    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      sample text simple a
+    </namerecord>
+    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      param1 text simple a
+    </namerecord>
+    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
+      param2 text simple a
+    </namerecord>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
       uilabel simple a
     </namerecord>
     <namerecord nameID="257" platformID="3" platEncID="1" langID="0x409">
       tool tip simple a
     </namerecord>
-    <namerecord nameID="257" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      tool tip simple a
-    </namerecord>
     <namerecord nameID="258" platformID="3" platEncID="1" langID="0x409">
-      sample text simple a
-    </namerecord>
-    <namerecord nameID="258" platformID="1" platEncID="0" langID="0x0" unicode="True">
       sample text simple a
     </namerecord>
     <namerecord nameID="259" platformID="3" platEncID="1" langID="0x409">
       param1 text simple a
     </namerecord>
-    <namerecord nameID="259" platformID="1" platEncID="0" langID="0x0" unicode="True">
-      param1 text simple a
-    </namerecord>
     <namerecord nameID="260" platformID="3" platEncID="1" langID="0x409">
-      param2 text simple a
-    </namerecord>
-    <namerecord nameID="260" platformID="1" platEncID="0" langID="0x0" unicode="True">
       param2 text simple a
     </namerecord>
   </name>

--- a/fonttools-tests/spec9e.ttx
+++ b/fonttools-tests/spec9e.ttx
@@ -2,10 +2,10 @@
 <ttFont>
 
   <name>
-    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
+    <namerecord nameID="9" platformID="1" platEncID="0" langID="0x0" unicode="True">
       Joachim Müller-Lancé
     </namerecord>
-    <namerecord nameID="9" platformID="1" platEncID="0" langID="0x0" unicode="True">
+    <namerecord nameID="9" platformID="3" platEncID="1" langID="0x409">
       Joachim Müller-Lancé
     </namerecord>
   </name>

--- a/scripts/update_fonttools_tests.sh
+++ b/scripts/update_fonttools_tests.sh
@@ -12,4 +12,5 @@ DEST_DIR=./fonttools-tests
 
 git clone $REPO $TEMP_DIR
 cp $TEST_DATA/*.fea $DEST_DIR
+cp $TEST_DATA/*.ttx $DEST_DIR
 rm -rf $TEMP_DIR


### PR DESCRIPTION
This brings in changes from the patch where feaLib now sorts the name table correctly, and it also brings in a few other upstream changes, including no longer promiting GPOS 8 to 7, which is a regression for us.